### PR TITLE
Added block size patch for triton

### DIFF
--- a/vllm/model_executor/layers/quantization/fp_quant_triton/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/fp_quant_triton/mxfp4.py
@@ -1,4 +1,4 @@
-from random import randint
+from itertools import product
 
 import torch
 import triton
@@ -9,15 +9,24 @@ def get_autotuning_config(configs, named_args, **kwargs):
     hadamard_dim = kwargs["hadamard_dim"]
     # Block size has to be chosen such, that BLOCK_SIZE // hadamard_dim is multiple of 16
     BLOCK_SIZES = [32 * 32, 64 * 32, 128 * 32, 256 * 32, 512 * 32]
-    for block_size in BLOCK_SIZES:
-        if block_size // hadamard_dim % 16 == 0:
-            configs.append(triton.Config({"BLOCK_SIZE": block_size}))
+
+    block_size_step = 16 * hadamard_dim
+
+    for config in configs:
+        num_warps = config.num_warps
+        num_stages = config.num_stages
+        for block_size in BLOCK_SIZES:
+            if block_size // block_size_step > 0 and block_size % block_size_step == 0:
+                yield triton.Config({"BLOCK_SIZE": block_size}, num_warps=num_warps, num_stages=num_stages) 
 
 
 @triton.autotune(
-    configs=[triton.Config({})],
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages) 
+        for num_stages, num_warps in product([1, 2], [1, 2, 4, 8])
+    ],
     prune_configs_by={"early_config_prune": get_autotuning_config},
-    key=[],
+    key=[]
 )
 @triton.jit
 def mxfp4_forward_kernel(

--- a/vllm/model_executor/layers/quantization/fp_quant_triton/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/fp_quant_triton/mxfp4.py
@@ -5,14 +5,18 @@ import triton
 import triton.language as tl
 
 
+def get_autotuning_config(configs, named_args, **kwargs):
+    hadamard_dim = kwargs["hadamard_dim"]
+    # Block size has to be chosen such, that BLOCK_SIZE // hadamard_dim is multiple of 16
+    BLOCK_SIZES = [32 * 32, 64 * 32, 128 * 32, 256 * 32, 512 * 32]
+    for block_size in BLOCK_SIZES:
+        if block_size // hadamard_dim % 16 == 0:
+            configs.append(triton.Config({"BLOCK_SIZE": block_size}))
+
+
 @triton.autotune(
-    configs=[
-        triton.Config({"BLOCK_SIZE": 32 * 32}),
-        triton.Config({"BLOCK_SIZE": 64 * 32}),
-        triton.Config({"BLOCK_SIZE": 128 * 32}),
-        triton.Config({"BLOCK_SIZE": 256 * 32}),
-        triton.Config({"BLOCK_SIZE": 512 * 32}),
-    ],
+    configs=[triton.Config({})],
+    prune_configs_by={"early_config_prune": get_autotuning_config},
     key=[],
 )
 @triton.jit

--- a/vllm/model_executor/layers/quantization/fp_quant_triton/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/fp_quant_triton/nvfp4.py
@@ -5,14 +5,18 @@ import triton
 import triton.language as tl
 
 
+def get_autotuning_config(configs, named_args, **kwargs):
+    hadamard_dim = kwargs["hadamard_dim"]
+    # Block size has to be chosen such, that BLOCK_SIZE // hadamard_dim is multiple of 16
+    BLOCK_SIZES = [32 * 32, 64 * 32, 128 * 32, 256 * 32, 512 * 32]
+    for block_size in BLOCK_SIZES:
+        if block_size // hadamard_dim % 16 == 0:
+            configs.append(triton.Config({"BLOCK_SIZE": block_size}))
+
+
 @triton.autotune(
-    configs=[
-        triton.Config({"BLOCK_SIZE": 32 * 32}),
-        triton.Config({"BLOCK_SIZE": 64 * 32}),
-        triton.Config({"BLOCK_SIZE": 128 * 32}),
-        triton.Config({"BLOCK_SIZE": 256 * 32}),
-        triton.Config({"BLOCK_SIZE": 512 * 32}),
-    ],
+    configs=[triton.Config({})],
+    prune_configs_by={"early_config_prune": get_autotuning_config},
     key=[],
 )
 @triton.jit

--- a/vllm/model_executor/layers/quantization/fp_quant_triton/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/fp_quant_triton/nvfp4.py
@@ -1,4 +1,4 @@
-from random import randint
+from itertools import product
 
 import torch
 import triton
@@ -9,15 +9,24 @@ def get_autotuning_config(configs, named_args, **kwargs):
     hadamard_dim = kwargs["hadamard_dim"]
     # Block size has to be chosen such, that BLOCK_SIZE // hadamard_dim is multiple of 16
     BLOCK_SIZES = [32 * 32, 64 * 32, 128 * 32, 256 * 32, 512 * 32]
-    for block_size in BLOCK_SIZES:
-        if block_size // hadamard_dim % 16 == 0:
-            configs.append(triton.Config({"BLOCK_SIZE": block_size}))
+
+    block_size_step = 16 * hadamard_dim
+
+    for config in configs:
+        num_warps = config.num_warps
+        num_stages = config.num_stages
+        for block_size in BLOCK_SIZES:
+            if block_size // block_size_step > 0 and block_size % block_size_step == 0:
+                yield triton.Config({"BLOCK_SIZE": block_size}, num_warps=num_warps, num_stages=num_stages) 
 
 
 @triton.autotune(
-    configs=[triton.Config({})],
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages) 
+        for num_stages, num_warps in product([1, 2], [1, 2, 4, 8])
+    ],
     prune_configs_by={"early_config_prune": get_autotuning_config},
-    key=[],
+    key=[]
 )
 @triton.jit
 def nvfp4_forward_kernel(


### PR DESCRIPTION
This PR implements a kernel config pruner to ensure all tensor shapes are divisible by 16, as required by `tl.dot`.
